### PR TITLE
modification to model to support associating with a user for an existing registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+*.pyc
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# OS generated files #
+######################
+.DS_Store?
+ehthumbs.db
+Icon?
+Thumbs.db

--- a/models.py
+++ b/models.py
@@ -99,7 +99,7 @@ class Club(m.Model):
 
 class Membership(m.Model): 
     
-    num = m.IntegerField("ID #",null=True,default=None)
+    num = m.IntegerField("ID #",null=True,default=None,autoincrement=True)
     
     start = m.DateField("Member Since")
     valid_thru = m.DateField("Valid Through")
@@ -277,6 +277,12 @@ class Registration(m.Model):
 	if self.reg_detail: 
 	    return "%s for %s"%(self.reg_detail.user.username,self.event.name)
 	return "anon: %s %s for %s"%(self.first_name,self.last_name,self.event.name)
+    
+    def associate_with_user(self,user): 
+	self._anon_f_name = "N/A"
+	self._anon_l_name = "N/A"
+	self.reg_detail = RegDetail()
+	self.reg_detai.user = user
     
     def clean(self): 
 	if not self.event.allow_number_race_class(self.number,self.race_class):

--- a/models.py
+++ b/models.py
@@ -282,7 +282,7 @@ class Registration(m.Model):
 	self._anon_f_name = "N/A"
 	self._anon_l_name = "N/A"
 	self.reg_detail = RegDetail()
-	self.reg_detai.user = user
+	self.reg_detail.user = user
     
     def clean(self): 
 	if not self.event.allow_number_race_class(self.number,self.race_class):


### PR DESCRIPTION
I added a method which allows the association of a user with a registration after the fact. Registrations can be created anonymously, because event organizers might type in a name wrong (mispelled) or they did not know the user name at the event. 

You need to associate with the right account though, so season points are calculated properly. A special view will have to be created to initiate the association. 
